### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+insert_final_newline = false
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[*.{json}]
+indent_style = space
+indent_size = 2
+
+[*.{html,css,js}]
+indent_style = tab
+indent_size = 4
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Add some code standard definitions to avoid mix code styles.
Info about Editor Config: https://editorconfig.org/

All files:
- Not add new line in the end of each file;
- Set charset to `utf-8`;
- Remove white-spaces in the end of lines;
- Set Line ending to LF (More info: https://en.wikipedia.org/wiki/Newline)

`*.json`
- Indent using spaces (Default to json files);
- Indent size: 2;

`*.html`, `*.css` and `*.js`
- Indent using tabs (Following the actual standard to the project);
- Indent size 4;

`*.md`, `*.markdown`
- Do not remove spaces in the end of lines (Markdown files use double spaces in the end of line to insert a <br/> element in compiled version);